### PR TITLE
Opt-out from Data Binding: migrate to View Binding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 MVVM + Clean Architecture with three layers:
 
-- **`ui/`** — Fragments + ViewModels (Hilt-injected), XML data binding, Navigation Component. Compose dependencies are present but UI is currently XML-based.
+- **`ui/`** — Fragments + ViewModels (Hilt-injected), View Binding, Navigation Component. Compose dependencies are present but UI is currently XML-based.
 - **`data/`** — Repository pattern with Room (local) and Retrofit/Moshi (remote). The repository interface abstracts both sources.
 - **`domain/`** — Business logic, decoupled from Android framework.
 - **`di/`** — Hilt modules: `DatabaseModule`, `AppModule` (DAOs), `DispatcherModule` (injects `@Main`, `@IO`, `@Default` coroutine dispatchers for testability).
@@ -36,7 +36,7 @@ Key patterns:
 - **Unit tests** (`src/test/`): Robolectric-based, run on JVM. Use `CustomTestRunner` with `HiltTestApplication`.
 - **Instrumented tests** (`src/androidTest/`): Espresso + UIAutomator. Managed device: Pixel 2 API 35 (AOSP-ATD).
 - **Shared test utilities** live in `src/sharedTest/`.
-- Coverage excludes DI modules, generated code, fragments, activities, and data binding classes.
+- Coverage excludes DI modules, generated code, fragments, activities, and binding classes.
 
 ## Code Quality
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ now [logged as issues](https://github.com/ryanw-mobile/nd940-cap-advanced-androi
 * Kotlin
 * Kotlin Coroutines and Flow
 * MVVM & clean architecture
-* XML Views
+* XML Views with View Binding
 * Device permission
 * Device location
 * Dark theme support

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
-        dataBinding = true
+        viewBinding = true
     }
 
     testOptions {

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/BindingAdapters.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/BindingAdapters.kt
@@ -1,24 +1,16 @@
 package com.example.android.politicalpreparedness.ui
 
-import android.widget.ArrayAdapter
 import android.widget.ImageView
-import android.widget.Spinner
-import android.widget.TextView
 import androidx.core.net.toUri
-import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
 import com.example.android.politicalpreparedness.R
-import java.text.SimpleDateFormat
-import java.util.Date
 
-@BindingAdapter("profileImage")
 fun fetchImage(
     view: ImageView,
     src: String?,
 ) {
     src?.let {
         val uri = it.toUri().buildUpon().scheme("https").build()
-        // COMPLETED: Add Glide call to load image and circle crop - user ic_profile as a placeholder and for errors.
         Glide.with(view)
             .load(uri)
             .placeholder(R.drawable.ic_profile)
@@ -27,30 +19,6 @@ fun fetchImage(
             .circleCrop()
             .into(view)
     } ?: run {
-        // src is null, we still have to show a placeholder
         view.setImageResource(R.drawable.ic_profile)
     }
 }
-
-@BindingAdapter("stateValue")
-fun Spinner.setNewValue(value: String?) {
-    val adapter = toTypedAdapter<String>(this.adapter as ArrayAdapter<*>)
-    val position =
-        when (adapter.getItem(0)) {
-            is String -> adapter.getPosition(value)
-            else -> this.selectedItemPosition
-        }
-    if (position >= 0) {
-        setSelection(position)
-    }
-}
-
-@BindingAdapter("toSimpleString")
-fun TextView.formatDateValue(value: Date?) {
-    val dateFormat = SimpleDateFormat("dd/MM/yyy")
-    text = value?.let {
-        dateFormat.format(it)
-    } ?: ""
-}
-
-inline fun <reified T> toTypedAdapter(adapter: ArrayAdapter<*>): ArrayAdapter<T> = adapter as ArrayAdapter<T>

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/election/ElectionListAdapter.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/election/ElectionListAdapter.kt
@@ -7,6 +7,8 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.android.politicalpreparedness.data.network.models.Election
 import com.example.android.politicalpreparedness.databinding.ViewholderElectionBinding
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class ElectionListAdapter(private val clickListener: ElectionListener) : ListAdapter<Election, ElectionViewHolder>(ElectionDiffCallback()) {
     override fun onCreateViewHolder(
@@ -29,22 +31,19 @@ class ElectionListAdapter(private val clickListener: ElectionListener) : ListAda
 
 // COMPLETED: Create ElectionViewHolder
 class ElectionViewHolder(val binding: ViewholderElectionBinding) : RecyclerView.ViewHolder(binding.root) {
+    private val dateFormat = SimpleDateFormat("dd/MM/yyy", Locale.getDefault())
+
     fun bind(
         listener: ElectionListener,
         item: Election,
     ) {
-        binding.apply {
-            election = item
-            clickListener = listener
-            executePendingBindings()
-        }
+        binding.root.setOnClickListener { listener.onClick(item) }
+        binding.listitemElectionTitle.text = item.name
+        binding.listitemElectionDate.text = dateFormat.format(item.electionDay)
     }
 
     // COMPLETED: Add companion object to inflate ViewHolder (from)
     companion object {
-        // @LayoutRes
-        // val LAYOUT = R.layout.viewholder_election
-
         fun from(parent: ViewGroup): ElectionViewHolder {
             val layoutInflater = LayoutInflater.from(parent.context)
             val binding = ViewholderElectionBinding.inflate(layoutInflater, parent, false)

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/election/ElectionListAdapter.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/election/ElectionListAdapter.kt
@@ -31,7 +31,7 @@ class ElectionListAdapter(private val clickListener: ElectionListener) : ListAda
 
 // COMPLETED: Create ElectionViewHolder
 class ElectionViewHolder(val binding: ViewholderElectionBinding) : RecyclerView.ViewHolder(binding.root) {
-    private val dateFormat = SimpleDateFormat("dd/MM/yyy", Locale.getDefault())
+    private val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
 
     fun bind(
         listener: ElectionListener,

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/election/ElectionsFragment.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/election/ElectionsFragment.kt
@@ -4,12 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
-import com.example.android.politicalpreparedness.R
 import com.example.android.politicalpreparedness.databinding.FragmentElectionBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -19,7 +17,7 @@ class ElectionsFragment : Fragment() {
     // Hilt DI - not using @Inject
     private val viewModel: ElectionsViewModel by viewModels()
 
-    lateinit var binding: FragmentElectionBinding
+    private lateinit var binding: FragmentElectionBinding
     private lateinit var electionUpcomingAdapter: ElectionListAdapter
     private lateinit var electionFollowedAdapter: ElectionListAdapter
 
@@ -28,13 +26,8 @@ class ElectionsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        // COMPLETED: Add ViewModel values and create ViewModel
-        // By Injection
-
         // COMPLETED: Add binding values
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_election, container, false)
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.viewModel = viewModel
+        binding = FragmentElectionBinding.inflate(inflater, container, false)
 
         // COMPLETED: Link elections to voter info
         viewModel.selectedElection.observe(

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/representative/RepresentativeFragment.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/representative/RepresentativeFragment.kt
@@ -66,32 +66,10 @@ class RepresentativeFragment : Fragment() {
         )
 
         // Sync address fields from ViewModel to UI (e.g. when location is used)
-        viewModel.address.observe(viewLifecycleOwner) { address ->
-            if (binding.addressLine1.text.toString() != address.line1) {
-                binding.addressLine1.setText(address.line1)
-            }
-            if (binding.addressLine2.text.toString() != (address.line2 ?: "")) {
-                binding.addressLine2.setText(address.line2 ?: "")
-            }
-            if (binding.city.text.toString() != address.city) {
-                binding.city.setText(address.city)
-            }
-            if (binding.zip.text.toString() != address.zip) {
-                binding.zip.setText(address.zip)
-            }
-            @Suppress("UNCHECKED_CAST")
-            val spinnerAdapter = binding.state.adapter as? ArrayAdapter<String>
-            val position = spinnerAdapter?.getPosition(address.state) ?: -1
-            if (position >= 0 && binding.state.selectedItemPosition != position) {
-                binding.state.setSelection(position)
-            }
-        }
+        viewModel.address.observe(viewLifecycleOwner) { address -> updateAddressFields(address) }
 
         // Sync EditText changes back to ViewModel address
-        binding.addressLine1.doAfterTextChanged { viewModel.address.value?.line1 = it.toString() }
-        binding.addressLine2.doAfterTextChanged { viewModel.address.value?.line2 = it.toString() }
-        binding.city.doAfterTextChanged { viewModel.address.value?.city = it.toString() }
-        binding.zip.doAfterTextChanged { viewModel.address.value?.zip = it.toString() }
+        setupAddressTextWatchers()
 
         // COMPLETED: Establish button listeners for field and location search
         binding.state.onItemSelectedListener =
@@ -116,6 +94,32 @@ class RepresentativeFragment : Fragment() {
         }
 
         return binding.root
+    }
+
+    private fun updateAddressFields(address: com.example.android.politicalpreparedness.data.network.models.Address) {
+        if (binding.addressLine1.text.toString() != address.line1) binding.addressLine1.setText(address.line1)
+        if (binding.addressLine2.text.toString() != (address.line2 ?: "")) binding.addressLine2.setText(address.line2 ?: "")
+        if (binding.city.text.toString() != address.city) binding.city.setText(address.city)
+        if (binding.zip.text.toString() != address.zip) binding.zip.setText(address.zip)
+        @Suppress("UNCHECKED_CAST")
+        val spinnerAdapter = binding.state.adapter as? ArrayAdapter<String>
+        val position = spinnerAdapter?.getPosition(address.state) ?: -1
+        if (position >= 0 && binding.state.selectedItemPosition != position) binding.state.setSelection(position)
+    }
+
+    private fun setupAddressTextWatchers() {
+        binding.addressLine1.doAfterTextChanged { text ->
+            viewModel.address.value?.let { if (it.line1 != text.toString()) it.line1 = text.toString() }
+        }
+        binding.addressLine2.doAfterTextChanged { text ->
+            viewModel.address.value?.let { if (it.line2 != text.toString()) it.line2 = text.toString() }
+        }
+        binding.city.doAfterTextChanged { text ->
+            viewModel.address.value?.let { if (it.city != text.toString()) it.city = text.toString() }
+        }
+        binding.zip.doAfterTextChanged { text ->
+            viewModel.address.value?.let { if (it.zip != text.toString()) it.zip = text.toString() }
+        }
     }
 
     /**

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/representative/RepresentativeFragment.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/representative/RepresentativeFragment.kt
@@ -15,9 +15,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
-import androidx.databinding.DataBindingUtil
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -37,7 +38,7 @@ class RepresentativeFragment : Fragment() {
     // Hilt DI - not using @Inject
     private val viewModel: RepresentativeViewModel by viewModels()
 
-    lateinit var binding: FragmentRepresentativeBinding
+    private lateinit var binding: FragmentRepresentativeBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -45,10 +46,7 @@ class RepresentativeFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View {
         // COMPLETED: Establish bindings
-        binding =
-            DataBindingUtil.inflate(inflater, R.layout.fragment_representative, container, false)
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.viewModel = viewModel
+        binding = FragmentRepresentativeBinding.inflate(inflater, container, false)
 
         // COMPLETED: Define and assign Representative adapter
         val representativesAdapter =
@@ -66,6 +64,34 @@ class RepresentativeFragment : Fragment() {
             viewLifecycleOwner,
             { representativesAdapter.submitList(it) },
         )
+
+        // Sync address fields from ViewModel to UI (e.g. when location is used)
+        viewModel.address.observe(viewLifecycleOwner) { address ->
+            if (binding.addressLine1.text.toString() != address.line1) {
+                binding.addressLine1.setText(address.line1)
+            }
+            if (binding.addressLine2.text.toString() != (address.line2 ?: "")) {
+                binding.addressLine2.setText(address.line2 ?: "")
+            }
+            if (binding.city.text.toString() != address.city) {
+                binding.city.setText(address.city)
+            }
+            if (binding.zip.text.toString() != address.zip) {
+                binding.zip.setText(address.zip)
+            }
+            @Suppress("UNCHECKED_CAST")
+            val spinnerAdapter = binding.state.adapter as? ArrayAdapter<String>
+            val position = spinnerAdapter?.getPosition(address.state) ?: -1
+            if (position >= 0 && binding.state.selectedItemPosition != position) {
+                binding.state.setSelection(position)
+            }
+        }
+
+        // Sync EditText changes back to ViewModel address
+        binding.addressLine1.doAfterTextChanged { viewModel.address.value?.line1 = it.toString() }
+        binding.addressLine2.doAfterTextChanged { viewModel.address.value?.line2 = it.toString() }
+        binding.city.doAfterTextChanged { viewModel.address.value?.city = it.toString() }
+        binding.zip.doAfterTextChanged { viewModel.address.value?.zip = it.toString() }
 
         // COMPLETED: Establish button listeners for field and location search
         binding.state.onItemSelectedListener =
@@ -91,15 +117,6 @@ class RepresentativeFragment : Fragment() {
 
         return binding.root
     }
-
-//    override fun onRequestPermissionsResult(
-//        requestCode: Int,
-//        permissions: Array<out String>,
-//        grantResults: IntArray
-//    ) {
-//        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-//        //COMPLETED: Handle location permission result to get location on permission granted
-//    }
 
     /**
      * The following permission request has been rewritten using the latest offering from Google.
@@ -164,20 +181,6 @@ class RepresentativeFragment : Fragment() {
                 }.show()
             }
         }
-
-//    private fun checkLocationPermissions(): Boolean {
-//        return if (isPermissionGranted()) {
-//            true
-//        } else {
-//            //COMPLETED: Request Location permissions
-//            false
-//        }
-//    }
-
-//    private fun isPermissionGranted(): Boolean {
-//        //COMPLETED Check if permission is already granted and return (true = granted, false = denied/other)
-//        return true
-//    }
 
     /**
      * Permission check has been skipped because this function is called only after checking for permission

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/representative/RepresentativeListAdapter.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/representative/RepresentativeListAdapter.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.android.politicalpreparedness.data.network.models.Channel
 import com.example.android.politicalpreparedness.databinding.ViewholderRepresentativeBinding
 import com.example.android.politicalpreparedness.domain.model.Representative
+import com.example.android.politicalpreparedness.ui.fetchImage
 
 class RepresentativeListAdapter : ListAdapter<Representative, RepresentativeViewHolder>(RepresentativeDiffCallback()) {
     override fun onCreateViewHolder(
@@ -31,14 +32,11 @@ class RepresentativeListAdapter : ListAdapter<Representative, RepresentativeView
 
 class RepresentativeViewHolder(private val binding: ViewholderRepresentativeBinding) : RecyclerView.ViewHolder(binding.root) {
     fun bind(item: Representative) {
-        // XML retrieves string values for text views
-        binding.representative = item
-
-        // TextView values are handled at XML
-
-        // Use Glide to take care of the profile image
-        // BindingAdapter is defined to supply the URL from the XML
-        // binding.representativePhoto.setImageResource(R.drawable.ic_profile)
+        binding.representativeOfficeName.text = item.office.name
+        binding.representativeName.text = item.official.name
+        binding.representativeParty.text = item.official.party ?: ""
+        binding.representativePhoto.contentDescription = item.official.name
+        fetchImage(binding.representativePhoto, item.official.photoUrl)
 
         // COMPLETED: Show social links ** Hint: Use provided helper methods
         // COMPLETED: Show www link ** Hint: Use provided helper methods
@@ -54,8 +52,6 @@ class RepresentativeViewHolder(private val binding: ViewholderRepresentativeBind
         item.official.urls?.let {
             showWWWLinks(it)
         }
-
-        binding.executePendingBindings()
     }
 
     // COMPLETED: Add companion object to inflate ViewHolder (from)

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/voterInfo/VoterInfoFragment.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/voterInfo/VoterInfoFragment.kt
@@ -6,13 +6,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.example.android.politicalpreparedness.R
 import com.example.android.politicalpreparedness.data.repository.ElectionsRepository
 import com.example.android.politicalpreparedness.databinding.FragmentVoterInfoBinding
 import dagger.hilt.android.AndroidEntryPoint
+import java.text.SimpleDateFormat
+import java.util.Locale
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -28,58 +29,46 @@ class VoterInfoFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-//        val args = VoterInfoFragmentArgs.fromBundle(requireArguments())
-
-        // COMPLETED: Add ViewModel values and create ViewModel
-//        val viewModelFactory =
-        //          VoterInfoViewModelFactory(electionsRepository, args.argElectionId, args.argDivision)
-//        val viewModel =
-//            ViewModelProvider(this, viewModelFactory).get(VoterInfoViewModel::class.java)
-
         // COMPLETED: Add binding values
-        val binding: FragmentVoterInfoBinding =
-            DataBindingUtil.inflate(inflater, R.layout.fragment_voter_info, container, false)
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.viewModel = viewModel
+        val binding = FragmentVoterInfoBinding.inflate(inflater, container, false)
 
-        // Hint: You will need to ensure proper data is provided from previous fragment.
-        viewModel.voterInfoLoadError.observe(
-            viewLifecycleOwner,
-            { error ->
-                if (error) {
-                    binding.dataScreen.visibility = View.GONE
-                    binding.loadingScreen.visibility = View.GONE
-                    binding.errorScreen.visibility = View.VISIBLE
-                }
-            },
-        )
+        // COMPLETED: Handle save button clicks
+        binding.buttonSave.setOnClickListener { viewModel.toggleFollowElection() }
 
-        // Control the visibility of the State Correspondence
-        // Could have a better way to do this
-        viewModel.voterInfo.observe(
-            viewLifecycleOwner,
-            {
-                // When it changes and have valid values, we update the UI
-                binding.apply {
-                    addressGroup.visibility =
-                        if (viewModel!!.getCorrespondenceAddress().isNullOrEmpty()) {
-                            View.GONE
-                        } else {
-                            View.VISIBLE
-                        }
-
-                    // COMPLETED: Handle loading of URLs
-                    stateLocations.setOnClickListener { openWebUrl(viewModel!!.getVotingLocationUrl()) }
-                    stateBallot.setOnClickListener { openWebUrl(viewModel!!.getBallotInformationUrl()) }
-                }
-            },
-        )
+        viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
+            binding.loadingScreen.visibility = if (isLoading) View.VISIBLE else View.GONE
+        }
 
         // COMPLETED: Handle save button UI state
-        // XML interacting with ViewModel directly
+        viewModel.isFollowed.observe(viewLifecycleOwner) { isFollowed ->
+            binding.buttonSave.text = getString(
+                if (isFollowed == true) R.string.unfollow_election else R.string.follow_election,
+            )
+        }
 
-        // COMPLETED: cont'd Handle save button clicks
-        // XML calling ViewModel function directly
+        // Hint: You will need to ensure proper data is provided from previous fragment.
+        viewModel.voterInfoLoadError.observe(viewLifecycleOwner) { error ->
+            if (error) {
+                binding.dataScreen.visibility = View.GONE
+                binding.loadingScreen.visibility = View.GONE
+                binding.errorScreen.visibility = View.VISIBLE
+            }
+        }
+
+        val dateFormat = SimpleDateFormat("dd/MM/yyy", Locale.getDefault())
+        viewModel.voterInfo.observe(viewLifecycleOwner) { voterInfo ->
+            binding.electionName.text = voterInfo.election.name
+            binding.electionDate.text = dateFormat.format(voterInfo.election.electionDay)
+            binding.address.text = viewModel.getCorrespondenceAddress() ?: ""
+
+            // Control the visibility of the State Correspondence
+            binding.addressGroup.visibility =
+                if (viewModel.getCorrespondenceAddress().isNullOrEmpty()) View.GONE else View.VISIBLE
+
+            // COMPLETED: Handle loading of URLs
+            binding.stateLocations.setOnClickListener { openWebUrl(viewModel.getVotingLocationUrl()) }
+            binding.stateBallot.setOnClickListener { openWebUrl(viewModel.getBallotInformationUrl()) }
+        }
 
         return binding.root
     }

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/voterInfo/VoterInfoFragment.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/destination/voterInfo/VoterInfoFragment.kt
@@ -55,7 +55,7 @@ class VoterInfoFragment : Fragment() {
             }
         }
 
-        val dateFormat = SimpleDateFormat("dd/MM/yyy", Locale.getDefault())
+        val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
         viewModel.voterInfo.observe(viewLifecycleOwner) { voterInfo ->
             binding.electionName.text = voterInfo.election.name
             binding.electionDate.text = dateFormat.format(voterInfo.election.electionDay)

--- a/app/src/main/java/com/example/android/politicalpreparedness/ui/launch/LaunchFragment.kt
+++ b/app/src/main/java/com/example/android/politicalpreparedness/ui/launch/LaunchFragment.kt
@@ -15,9 +15,8 @@ class LaunchFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View? {
-        val binding = FragmentLaunchBinding.inflate(inflater)
-        binding.lifecycleOwner = viewLifecycleOwner
+    ): View {
+        val binding = FragmentLaunchBinding.inflate(inflater, container, false)
 
         binding.representativeButton.setOnClickListener { navToRepresentatives() }
         binding.upcomingButton.setOnClickListener { navToElections() }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,44 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <data>
-
-    </data>
-
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/coordinator_layout"
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
-        <com.google.android.material.appbar.AppBarLayout
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/top_appbar"
+            style="@style/Widget.MaterialComponents.Toolbar.Primary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/top_appbar"
-                style="@style/Widget.MaterialComponents.Toolbar.Primary"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+            <TextView
+                style="@style/TextAppearance.AppCompat.Headline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:text="@string/app_name"
+                android:textColor="@color/md_theme_onPrimary" />
+        </com.google.android.material.appbar.MaterialToolbar>
+    </com.google.android.material.appbar.AppBarLayout>
 
-                <TextView
-                    style="@style/TextAppearance.AppCompat.Headline"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:text="@string/app_name"
-                    android:textColor="@color/md_theme_onPrimary" />
-            </com.google.android.material.appbar.MaterialToolbar>
-        </com.google.android.material.appbar.AppBarLayout>
+    <fragment
+        android:id="@+id/nav_host"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        app:navGraph="@navigation/nav_graph" />
 
-        <fragment
-            android:id="@+id/nav_host"
-            android:name="androidx.navigation.fragment.NavHostFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:defaultNavHost="true"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
-            app:navGraph="@navigation/nav_graph" />
-
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
-</layout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_election.xml
+++ b/app/src/main/res/layout/fragment_election.xml
@@ -1,63 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.example.android.politicalpreparedness.ui.MainActivity">
 
-    <!-- COMPLETED: Add node to connect Election ViewModel -->
-    <data>
+    <!-- COMPLETED: Add Upcoming Election Recycler and Header -->
+    <TextView
+        android:id="@+id/textview_upcoming_elections"
+        style="@style/sectionHeader"
+        android:text="@string/upcoming_elections"
+        app:layout_constraintBottom_toTopOf="@id/recyclerview_upcoming"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="spread" />
 
-        <variable
-            name="viewModel"
-            type="com.example.android.politicalpreparedness.ui.destination.election.ElectionsViewModel" />
-    </data>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerview_upcoming"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context="com.example.android.politicalpreparedness.ui.MainActivity">
+        android:layout_height="0px"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toTopOf="@id/textview_saved_elections"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/textview_upcoming_elections"
+        app:layout_constraintVertical_weight="1" />
 
-        <!-- COMPLETED: Add Upcoming Election Recycler and Header -->
-        <TextView
-            android:id="@+id/textview_upcoming_elections"
-            style="@style/sectionHeader"
-            android:text="@string/upcoming_elections"
-            app:layout_constraintBottom_toTopOf="@id/recyclerview_upcoming"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_chainStyle="spread" />
+    <!-- COMPLETED: Add Saved Election Recycler and Header -->
+    <TextView
+        android:id="@+id/textview_saved_elections"
+        style="@style/sectionHeader"
+        android:text="@string/saved_elections"
+        app:layout_constraintBottom_toTopOf="@id/recyclerview_saved"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/recyclerview_upcoming" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerview_upcoming"
-            android:layout_width="match_parent"
-            android:layout_height="0px"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toTopOf="@id/textview_saved_elections"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/textview_upcoming_elections"
-            app:layout_constraintVertical_weight="1" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerview_saved"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/textview_saved_elections"
+        app:layout_constraintVertical_weight="1" />
 
-        <!-- COMPLETED: Add Saved Election Recycler and Header -->
-        <TextView
-            android:id="@+id/textview_saved_elections"
-            style="@style/sectionHeader"
-            android:text="@string/saved_elections"
-            app:layout_constraintBottom_toTopOf="@id/recyclerview_saved"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/recyclerview_upcoming" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerview_saved"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/textview_saved_elections"
-            app:layout_constraintVertical_weight="1" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</layout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_launch.xml
+++ b/app/src/main/res/layout/fragment_launch.xml
@@ -1,41 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/double_padding"
+    tools:context="com.example.android.politicalpreparedness.ui.MainActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:padding="@dimen/double_padding"
-        tools:context="com.example.android.politicalpreparedness.ui.MainActivity">
+    <!-- COMPLETED: Add image for home screen logo. -->
+    <ImageView
+        android:id="@+id/launch_logo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/upcoming_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ballot_logo" />
 
-        <!-- COMPLETED: Add image for home screen logo. -->
-        <ImageView
-            android:id="@+id/launch_logo"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toTopOf="@+id/upcoming_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ballot_logo" />
+    <!-- COMPLETED: Add Button to navigate to upcoming elections. -->
+    <Button
+        android:id="@+id/upcoming_button"
+        style="@style/election_button"
+        android:text="@string/upcoming_elections"
+        app:layout_constraintBottom_toTopOf="@id/representative_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-        <!-- COMPLETED: Add Button to navigate to upcoming elections. -->
-        <Button
-            android:id="@+id/upcoming_button"
-            style="@style/election_button"
-            android:text="@string/upcoming_elections"
-            app:layout_constraintBottom_toTopOf="@id/representative_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-        <!-- COMPLETED: Add Button to navigate to representatives. -->
-        <Button
-            android:id="@+id/representative_button"
-            style="@style/election_button"
-            android:text="@string/find_my_representatives"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</layout>
+    <!-- COMPLETED: Add Button to navigate to representatives. -->
+    <Button
+        android:id="@+id/representative_button"
+        style="@style/election_button"
+        android:text="@string/find_my_representatives"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_representative.xml
+++ b/app/src/main/res/layout/fragment_representative.xml
@@ -1,169 +1,149 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.motion.widget.MotionLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layoutDescription="@xml/fragment_representative_scene"
     tools:context="com.example.android.politicalpreparedness.ui.MainActivity">
 
-    <!-- COMPLETED: Add data binding node -->
-    <data>
-
-        <variable
-            name="viewModel"
-            type="com.example.android.politicalpreparedness.ui.destination.representative.RepresentativeViewModel" />
-
-        <variable
-            name="address"
-            type="com.example.android.politicalpreparedness.data.network.models.Address" />
-    </data>
-
-    <!-- COMPLETED: Add motion scene to hide form on vertical scroll. -->
-    <androidx.constraintlayout.motion.widget.MotionLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/search_form"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layoutDescription="@xml/fragment_representative_scene">
+        android:layout_height="wrap_content"
+        android:background="@color/md_theme_primaryContainer"
+        app:layout_constraintBottom_toTopOf="@id/representative_results_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/search_form"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/md_theme_primaryContainer"
-            app:layout_constraintBottom_toTopOf="@id/representative_results_layout"
+        <!-- COMPLETED: Add visual styling and content -->
+        <TextView
+            android:id="@+id/search_title"
+            style="@style/sectionHeader"
+            android:text="@string/representative_search"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <!-- COMPLETED: Add visual styling and content -->
-            <TextView
-                android:id="@+id/search_title"
-                style="@style/sectionHeader"
-                android:text="@string/representative_search"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+        <!-- COMPLETED: Add data binding value -->
+        <!-- COMPLETED: Add visual styling and content -->
+        <EditText
+            android:id="@+id/address_line_1"
+            style="@style/representativeEditText"
+            android:hint="@string/address_line_1"
+            android:inputType="textPostalAddress"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/search_title" />
 
-            <!-- COMPLETED: Add data binding value -->
-            <!-- COMPLETED: Add visual styling and content -->
-            <EditText
-                android:id="@+id/address_line_1"
-                style="@style/representativeEditText"
-                android:hint="@string/address_line_1"
-                android:inputType="textPostalAddress"
-                android:text="@={viewModel.address.line1}"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/search_title" />
+        <!-- COMPLETED: Add data binding value -->
+        <!-- COMPLETED: Add visual styling and content -->
+        <EditText
+            android:id="@+id/address_line_2"
+            style="@style/representativeEditText"
+            android:hint="@string/address_line_2"
+            android:inputType="textPostalAddress"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/address_line_1" />
 
-            <!-- COMPLETED: Add data binding value -->
-            <!-- COMPLETED: Add visual styling and content -->
-            <EditText
-                android:id="@+id/address_line_2"
-                style="@style/representativeEditText"
-                android:hint="@string/address_line_2"
-                android:inputType="textPostalAddress"
-                android:text="@={viewModel.address.line2}"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/address_line_1" />
+        <!-- COMPLETED: Add data binding value -->
+        <!-- COMPLETED: Add visual styling and content -->
+        <EditText
+            android:id="@+id/city"
+            style="@style/representativeEditText"
+            android:hint="@string/city"
+            android:inputType="textPostalAddress"
+            app:layout_constraintEnd_toStartOf="@id/state"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/address_line_2" />
 
-            <!-- COMPLETED: Add data binding value -->
-            <!-- COMPLETED: Add visual styling and content -->
-            <EditText
-                android:id="@+id/city"
-                style="@style/representativeEditText"
-                android:hint="@string/city"
-                android:inputType="textPostalAddress"
-                android:text="@={viewModel.address.city}"
-                app:layout_constraintEnd_toStartOf="@id/state"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/address_line_2" />
+        <!-- COMPLETED: Add default values from provided resources  -->
+        <!-- COMPLETED: Add data binding value -->
+        <!-- COMPLETED: Add visual styling and content -->
+        <Spinner
+            android:id="@+id/state"
+            style="@style/Widget.AppCompat.Spinner"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/default_padding"
+            android:autofillHints=""
+            android:background="@color/md_theme_surfaceVariant"
+            android:drawSelectorOnTop="true"
+            android:entries="@array/states"
+            android:fontFamily="@font/merriweather_sans"
+            android:inputType="textPostalAddress"
+            android:minHeight="@dimen/min_clickable_height"
+            app:layout_constraintBottom_toBottomOf="@id/city"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/city"
+            app:layout_constraintTop_toTopOf="@id/city" />
 
-            <!-- COMPLETED: Add default values from provided resources  -->
-            <!-- COMPLETED: Add data binding value -->
-            <!-- COMPLETED: Add visual styling and content -->
-            <Spinner
-                android:id="@+id/state"
-                style="@style/Widget.AppCompat.Spinner"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/default_padding"
-                android:autofillHints=""
-                android:background="@color/md_theme_surfaceVariant"
-                android:drawSelectorOnTop="true"
-                android:entries="@array/states"
-                android:fontFamily="@font/merriweather_sans"
-                android:inputType="textPostalAddress"
-                android:minHeight="@dimen/min_clickable_height"
-                app:layout_constraintBottom_toBottomOf="@id/city"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/city"
-                app:layout_constraintTop_toTopOf="@id/city"
-                app:stateValue="@{viewModel.address.state}" />
+        <!-- COMPLETED: Add data binding value -->
+        <!-- COMPLETED: Add visual styling and content -->
+        <EditText
+            android:id="@+id/zip"
+            style="@style/representativeEditText"
+            android:hint="@string/zip"
+            android:inputType="number"
+            app:layout_constraintEnd_toStartOf="@id/state"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/city" />
 
-            <!-- COMPLETED: Add data binding value -->
-            <!-- COMPLETED: Add visual styling and content -->
-            <EditText
-                android:id="@+id/zip"
-                style="@style/representativeEditText"
-                android:hint="@string/zip"
-                android:inputType="number"
-                android:text="@={viewModel.address.zip}"
-                app:layout_constraintEnd_toStartOf="@id/state"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/city" />
+        <!-- COMPLETED: Add visual styling and label -->
+        <Button
+            android:id="@+id/button_search"
+            style="@style/Widget.AppCompat.Button.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/default_padding"
+            android:text="@string/find_my_representatives"
+            app:layout_constraintTop_toBottomOf="@id/zip" />
 
-            <!-- COMPLETED: Add visual styling and label -->
-            <Button
-                android:id="@+id/button_search"
-                style="@style/Widget.AppCompat.Button.Colored"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/default_padding"
-                android:text="@string/find_my_representatives"
-                app:layout_constraintTop_toBottomOf="@id/zip" />
+        <!-- COMPLETED: Add visual styling and content -->
+        <Button
+            android:id="@+id/button_location"
+            style="@style/Widget.AppCompat.Button.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/default_padding"
+            android:text="@string/use_my_location"
+            app:layout_constraintTop_toBottomOf="@id/button_search" />
 
-            <!-- COMPLETED: Add visual styling and content -->
-            <Button
-                android:id="@+id/button_location"
-                style="@style/Widget.AppCompat.Button.Colored"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/default_padding"
-                android:text="@string/use_my_location"
-                app:layout_constraintTop_toBottomOf="@id/button_search" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/representative_results_layout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/search_form"
+        app:layout_constraintVertical_weight="1">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/representative_results_layout"
+        <!-- COMPLETED: Add visual styling and content -->
+        <TextView
+            android:id="@+id/representative_title"
+            style="@style/sectionHeader"
+            android:text="@string/my_representatives"
+            app:layout_constraintBottom_toTopOf="@id/representative_recyclerview"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <!-- COMPLETED: Add Representatives RecyclerView -->
+        <!-- COMPLETED: Add visual styling and content -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/representative_recyclerview"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/search_form"
-            app:layout_constraintVertical_weight="1">
-
-            <!-- COMPLETED: Add visual styling and content -->
-            <TextView
-                android:id="@+id/representative_title"
-                style="@style/sectionHeader"
-                android:text="@string/my_representatives"
-                app:layout_constraintBottom_toTopOf="@id/representative_recyclerview"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <!-- COMPLETED: Add Representatives RecyclerView -->
-            <!-- COMPLETED: Add visual styling and content -->
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/representative_recyclerview"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/representative_title" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.constraintlayout.motion.widget.MotionLayout>
-</layout>
+            app:layout_constraintTop_toBottomOf="@id/representative_title" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.motion.widget.MotionLayout>

--- a/app/src/main/res/layout/fragment_voter_info.xml
+++ b/app/src/main/res/layout/fragment_voter_info.xml
@@ -1,178 +1,147 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     tools:context="com.example.android.politicalpreparedness.ui.MainActivity">
 
-    <!-- COMPLETED: Add data binding node for Voter Info ViewModel -->
-    <data>
-
-        <variable
-            name="viewModel"
-            type="com.example.android.politicalpreparedness.ui.destination.voterInfo.VoterInfoViewModel" />
-
-        <variable
-            name="voterInfo"
-            type="com.example.android.politicalpreparedness.data.network.models.VoterInfoResponse" />
-
-        <variable
-            name="election"
-            type="com.example.android.politicalpreparedness.data.network.models.Election" />
-
-        <variable
-            name="division"
-            type="com.example.android.politicalpreparedness.data.network.models.Division" />
-
-        <import type="android.view.View" />
-    </data>
-
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/data_screen"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:padding="@dimen/double_padding">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/data_screen"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="@dimen/double_padding"
-            tools:visibility="gone">
+        <!-- COMPLETED: Add title to toolbar -->
+        <TextView
+            android:id="@+id/election_name"
+            style="@style/election_name"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Election name" />
 
-            <!-- COMPLETED: Add title to toolbar -->
-            <TextView
-                android:id="@+id/election_name"
-                style="@style/election_name"
-                android:text="@{viewModel.voterInfo.election.name}"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="Election name" />
+        <!-- COMPLETED: Add visual styling -->
+        <TextView
+            android:id="@+id/election_date"
+            style="@style/election_date_header"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/election_name"
+            tools:text="12 November 2021" />
 
-            <!-- COMPLETED: Add visual styling -->
-            <TextView
-                android:id="@+id/election_date"
-                style="@style/election_date_header"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/election_name"
-                app:toSimpleString="@{viewModel.voterInfo.election.electionDay}"
-                tools:text="12 November 2021" />
-
-            <!-- COMPLETED: Add visual styling and content -->
-            <LinearLayout
-                android:id="@+id/election_information_box"
-                style="@style/election_information_box"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/election_date">
-
-                <TextView
-                    android:id="@+id/state_header"
-                    style="@style/election_information"
-                    android:text="@string/election_information" />
-
-                <!-- COMPLETED: Add click binding to open web URL -->
-                <!-- COMPLETED: Add visual styling and content -->
-                <TextView
-                    android:id="@+id/state_locations"
-                    style="@style/election_button"
-                    android:text="@string/voting_locations" />
-
-                <!-- COMPLETED: Add click binding to open web URL -->
-                <!-- COMPLETED: Add visual styling and content -->
-                <TextView
-                    android:id="@+id/state_ballot"
-                    style="@style/election_button"
-                    android:text="@string/ballot_information" />
-            </LinearLayout>
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/address_group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:constraint_referenced_ids="divider,state_correspondence_header,address"
-                tools:visibility="visible" />
-
-            <!-- COMPLETED: Add visual styling and content -->
-            <View
-                android:id="@+id/divider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginTop="@dimen/double_padding"
-                android:layout_marginBottom="@dimen/double_padding"
-                android:background="?android:attr/listDivider"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/election_information_box" />
-
-            <TextView
-                android:id="@+id/state_correspondence_header"
-                style="@style/state_correspondence"
-                android:text="@string/state_correspondence"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/divider" />
-
-            <!-- COMPLETED: Add data binding -->
-            <TextView
-                android:id="@+id/address"
-                style="@style/state_correspondence_address"
-                android:text="@{viewModel.voterInfo.state.get(0).electionAdministrationBody.correspondenceAddress.toFormattedString()}"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/state_correspondence_header"
-                tools:text="Address" />
-
-            <!-- COMPLETED: Add button to save election to Room -->
-            <Button
-                android:id="@+id/button_save"
-                style="@style/election_button"
-                android:onClick="@{()->viewModel.toggleFollowElection()}"
-                android:text="@{viewModel.isFollowed() ? @string/unfollow_election : @string/follow_election}"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                tools:text="@string/follow_election" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <RelativeLayout
-            android:id="@+id/loading_screen"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/color_loadingmask"
-            android:visibility="@{viewModel.isLoading()? View.VISIBLE : View.GONE}"
-            tools:visibility="gone">
-
-            <com.google.android.material.progressindicator.CircularProgressIndicator
-                android:id="@+id/loading_progress"
-                style="@style/Widget.Material3.CircularProgressIndicator.Medium"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:indeterminate="true" />
-
-        </RelativeLayout>
-
+        <!-- COMPLETED: Add visual styling and content -->
         <LinearLayout
-            android:id="@+id/error_screen"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:orientation="vertical"
-            android:visibility="@{viewModel.voterInfoLoadError? View.VISIBLE : View.GONE}"
-            tools:visibility="visible">
-
-            <ImageView
-                style="@style/errorscreen_icon"
-                android:contentDescription="@string/error"
-                android:src="@drawable/ic_baseline_error_outline_24"
-                app:tint="@color/md_theme_error" />
+            android:id="@+id/election_information_box"
+            style="@style/election_information_box"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/election_date">
 
             <TextView
-                android:id="@+id/error_textview"
-                style="@style/errorscreen_text"
-                android:text="@string/error_load_voterinfo" />
+                android:id="@+id/state_header"
+                style="@style/election_information"
+                android:text="@string/election_information" />
 
+            <!-- COMPLETED: Add click binding to open web URL -->
+            <!-- COMPLETED: Add visual styling and content -->
+            <TextView
+                android:id="@+id/state_locations"
+                style="@style/election_button"
+                android:text="@string/voting_locations" />
+
+            <!-- COMPLETED: Add click binding to open web URL -->
+            <!-- COMPLETED: Add visual styling and content -->
+            <TextView
+                android:id="@+id/state_ballot"
+                style="@style/election_button"
+                android:text="@string/ballot_information" />
         </LinearLayout>
-    </FrameLayout>
-</layout>
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/address_group"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:constraint_referenced_ids="divider,state_correspondence_header,address" />
+
+        <!-- COMPLETED: Add visual styling and content -->
+        <View
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="@dimen/double_padding"
+            android:layout_marginBottom="@dimen/double_padding"
+            android:background="?android:attr/listDivider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/election_information_box" />
+
+        <TextView
+            android:id="@+id/state_correspondence_header"
+            style="@style/state_correspondence"
+            android:text="@string/state_correspondence"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider" />
+
+        <!-- COMPLETED: Add data binding -->
+        <TextView
+            android:id="@+id/address"
+            style="@style/state_correspondence_address"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/state_correspondence_header"
+            tools:text="Address" />
+
+        <!-- COMPLETED: Add button to save election to Room -->
+        <Button
+            android:id="@+id/button_save"
+            style="@style/election_button"
+            android:text="@string/follow_election"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <RelativeLayout
+        android:id="@+id/loading_screen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/color_loadingmask"
+        android:visibility="gone"
+        tools:visibility="gone">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/loading_progress"
+            style="@style/Widget.Material3.CircularProgressIndicator.Medium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:indeterminate="true" />
+
+    </RelativeLayout>
+
+    <LinearLayout
+        android:id="@+id/error_screen"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone"
+        tools:visibility="gone">
+
+        <ImageView
+            style="@style/errorscreen_icon"
+            android:contentDescription="@string/error"
+            android:src="@drawable/ic_baseline_error_outline_24"
+            app:tint="@color/md_theme_error" />
+
+        <TextView
+            android:id="@+id/error_textview"
+            style="@style/errorscreen_text"
+            android:text="@string/error_load_voterinfo" />
+
+    </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/viewholder_election.xml
+++ b/app/src/main/res/layout/viewholder_election.xml
@@ -1,39 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/double_padding"
+    android:layout_marginEnd="@dimen/double_padding"
+    android:gravity="center"
+    android:minHeight="@dimen/min_clickable_height"
+    android:orientation="vertical">
 
-    <data>
+    <TextView
+        android:id="@+id/listitem_election_title"
+        style="@style/election_title"
+        tools:text="VIP Test Election" />
 
-        <variable
-            name="election"
-            type="com.example.android.politicalpreparedness.data.network.models.Election" />
-
-        <variable
-            name="clickListener"
-            type="com.example.android.politicalpreparedness.ui.destination.election.ElectionListener" />
-    </data>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/double_padding"
-        android:layout_marginEnd="@dimen/double_padding"
-        android:gravity="center"
-        android:minHeight="@dimen/min_clickable_height"
-        android:onClick="@{() -> clickListener.onClick(election)}"
-        android:orientation="vertical">
-
-        <TextView
-            android:id="@+id/listitem_election_title"
-            style="@style/election_title"
-            android:text="@{election.name}"
-            tools:text="VIP Test Election" />
-
-        <TextView
-            android:id="@+id/listitem_election_date"
-            style="@style/election_date"
-            app:toSimpleString="@{election.electionDay}"
-            tools:text="07/12/2021" />
-    </LinearLayout>
-</layout>
+    <TextView
+        android:id="@+id/listitem_election_date"
+        style="@style/election_date"
+        tools:text="07/12/2021" />
+</LinearLayout>

--- a/app/src/main/res/layout/viewholder_representative.xml
+++ b/app/src/main/res/layout/viewholder_representative.xml
@@ -1,97 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/min_clickable_height"
+    android:padding="@dimen/default_padding">
 
-    <data>
+    <ImageView
+        android:id="@+id/representative_photo"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/ic_profile" />
 
-        <variable
-            name="representative"
-            type="com.example.android.politicalpreparedness.domain.model.Representative" />
-    </data>
+    <TextView
+        android:id="@+id/representative_office_name"
+        style="@style/representative_office_name"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/representative_photo"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="U.S. Senator" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="@dimen/min_clickable_height"
-        android:padding="@dimen/default_padding">
+    <TextView
+        android:id="@+id/representative_name"
+        style="@style/representative_name"
+        app:layout_constraintEnd_toStartOf="@id/www_icon"
+        app:layout_constraintStart_toEndOf="@id/representative_photo"
+        app:layout_constraintTop_toBottomOf="@id/representative_office_name"
+        tools:text="Senator Name" />
 
-        <ImageView
-            android:id="@+id/representative_photo"
-            android:layout_width="64dp"
-            android:layout_height="64dp"
-            android:contentDescription="@{representative.official.name}"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:profileImage="@{representative.official.photoUrl}"
-            tools:src="@drawable/ic_profile" />
+    <TextView
+        android:id="@+id/representative_party"
+        style="@style/representative_party"
+        app:layout_constraintEnd_toStartOf="@id/www_icon"
+        app:layout_constraintStart_toEndOf="@id/representative_photo"
+        app:layout_constraintTop_toBottomOf="@id/representative_name"
+        tools:text="Republican Party" />
 
-        <TextView
-            android:id="@+id/representative_office_name"
-            style="@style/representative_office_name"
-            android:text="@{representative.office.name}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/representative_photo"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="U.S. Senator" />
+    <ImageView
+        android:id="@+id/www_icon"
+        android:layout_width="@dimen/min_clickable_height"
+        android:layout_height="@dimen/min_clickable_height"
+        android:clickable="true"
+        android:contentDescription="@string/website_link"
+        android:focusable="true"
+        android:padding="@dimen/default_padding"
+        android:src="@drawable/ic_www"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/facebook_icon"
+        app:layout_constraintTop_toBottomOf="@id/representative_office_name" />
 
-        <TextView
-            android:id="@+id/representative_name"
-            style="@style/representative_name"
-            android:text="@{representative.official.name}"
-            app:layout_constraintEnd_toStartOf="@id/www_icon"
-            app:layout_constraintStart_toEndOf="@id/representative_photo"
-            app:layout_constraintTop_toBottomOf="@id/representative_office_name"
-            tools:text="Senator Name" />
+    <ImageView
+        android:id="@+id/facebook_icon"
+        android:layout_width="@dimen/min_clickable_height"
+        android:layout_height="@dimen/min_clickable_height"
+        android:clickable="true"
+        android:contentDescription="@string/facebook_link"
+        android:focusable="true"
+        android:padding="@dimen/default_padding"
+        android:src="@drawable/ic_facebook"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/twitter_icon"
+        app:layout_constraintTop_toBottomOf="@id/representative_office_name" />
 
-        <TextView
-            android:id="@+id/representative_party"
-            style="@style/representative_party"
-            android:text="@{representative.official.party}"
-            app:layout_constraintEnd_toStartOf="@id/www_icon"
-            app:layout_constraintStart_toEndOf="@id/representative_photo"
-            app:layout_constraintTop_toBottomOf="@id/representative_name"
-            tools:text="Republican Party" />
+    <ImageView
+        android:id="@+id/twitter_icon"
+        android:layout_width="@dimen/min_clickable_height"
+        android:layout_height="@dimen/min_clickable_height"
+        android:clickable="true"
+        android:contentDescription="@string/twitter_link"
+        android:focusable="true"
+        android:padding="@dimen/default_padding"
+        android:src="@drawable/ic_twitter"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/representative_office_name" />
 
-        <ImageView
-            android:id="@+id/www_icon"
-            android:layout_width="@dimen/min_clickable_height"
-            android:layout_height="@dimen/min_clickable_height"
-            android:clickable="true"
-            android:contentDescription="@string/website_link"
-            android:focusable="true"
-            android:padding="@dimen/default_padding"
-            android:src="@drawable/ic_www"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/facebook_icon"
-            app:layout_constraintTop_toBottomOf="@id/representative_office_name" />
-
-        <ImageView
-            android:id="@+id/facebook_icon"
-            android:layout_width="@dimen/min_clickable_height"
-            android:layout_height="@dimen/min_clickable_height"
-            android:clickable="true"
-            android:contentDescription="@string/facebook_link"
-            android:focusable="true"
-            android:padding="@dimen/default_padding"
-            android:src="@drawable/ic_facebook"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/twitter_icon"
-            app:layout_constraintTop_toBottomOf="@id/representative_office_name" />
-
-        <ImageView
-            android:id="@+id/twitter_icon"
-            android:layout_width="@dimen/min_clickable_height"
-            android:layout_height="@dimen/min_clickable_height"
-            android:clickable="true"
-            android:contentDescription="@string/twitter_link"
-            android:focusable="true"
-            android:padding="@dimen/default_padding"
-            android:src="@drawable/ic_twitter"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/representative_office_name" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</layout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Closes #7

## Summary
- Switch `buildFeatures { dataBinding = true }` to `viewBinding = true` in `app/build.gradle.kts`
- Remove `<layout>` / `<data>` wrappers and all `@{...}` / `@={...}` binding expressions from all 7 layout XML files
- Move UI-update logic into Kotlin: observers in `VoterInfoFragment` drive election name, date, address, loading/error states and button text; `TextWatcher`s in `RepresentativeFragment` keep address fields in sync with the ViewModel; `ElectionViewHolder` and `RepresentativeViewHolder` set values directly in `bind()`
- Remove `@BindingAdapter` annotations from `BindingAdapters.kt`; `fetchImage()` is now called directly from `RepresentativeListAdapter`
- Update `CLAUDE.md` and `README.md` to reflect View Binding

## Test plan
- [ ] App builds cleanly with `./gradlew assembleDebug`
- [ ] All unit tests pass: `./gradlew :app:test`
- [ ] `./gradlew detekt check` reports no issues
- [ ] Launch screen navigates correctly to Elections and Representatives
- [ ] Elections list loads and tapping an item opens Voter Info
- [ ] Voter Info shows election name, date, address, follow/unfollow button updates correctly
- [ ] Representatives: manual address entry, GPS location button, search all work
- [ ] Representative list displays photo (Glide), office name, name, party, and social links correctly

🤖 Generated with [Claude Code](https://claude.ai/code)